### PR TITLE
feat: add a base http-app helm chart

### DIFF
--- a/charts/http-app/Chart.yaml
+++ b/charts/http-app/Chart.yaml
@@ -1,0 +1,18 @@
+apiVersion: v2
+name: http-app
+description: |
+  This is a simple HTTP application helm chart. If your container has a web server,
+  and you know on which port it is running, you can use this chart to expose it.
+
+maintainers:
+  - name: Henrique Cunha
+    email: henrique.cunha@clicampo.com.br
+  - name: Gabriel Montañola
+    email: gabriel@montanola.com
+    
+sources:
+  - https://github.com/clicampo/helm-charts
+
+
+type: application
+version: "0.1.0"

--- a/charts/http-app/templates/_helpers.tpl
+++ b/charts/http-app/templates/_helpers.tpl
@@ -49,14 +49,3 @@ Selector labels
 app.kubernetes.io/name: {{ include "http-app.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
-
-{{/*
-Create the name of the service account to use
-*/}}
-{{- define "http-app.serviceAccountName" -}}
-{{- if .Values.serviceAccount.create }}
-{{- default (include "http-app.fullname" .) .Values.serviceAccount.name }}
-{{- else }}
-{{- default "default" .Values.serviceAccount.name }}
-{{- end }}
-{{- end }}

--- a/charts/http-app/templates/_helpers.tpl
+++ b/charts/http-app/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "http-app.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "http-app.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "http-app.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "http-app.labels" -}}
+helm.sh/chart: {{ include "http-app.chart" . }}
+{{ include "http-app.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "http-app.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "http-app.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "http-app.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "http-app.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/http-app/templates/deployment.yaml
+++ b/charts/http-app/templates/deployment.yaml
@@ -1,0 +1,76 @@
+{{- $fullName := include "http-app.fullname" . -}}
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "http-app.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "http-app.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "http-app.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.port }}
+              protocol: TCP
+          livenessProbe:
+            initialDelaySeconds: 10
+            httpGet:
+              path: /docs
+              port: http
+          readinessProbe:
+            initialDelaySeconds: 10
+            httpGet:
+              path: /docs
+              port: http
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          {{- if .Values.env }}
+          env:
+            {{- range $element := .Values.env }}
+            - name: {{ $element.name }}
+              {{- if $element.value }}
+              value: {{ $element.value }}
+              {{- else if $element.fromVault }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $fullName }}-secret
+                  key: {{ $element.name }}
+              {{- end }}
+            {{- end }}
+          {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/http-app/templates/hpa.yaml
+++ b/charts/http-app/templates/hpa.yaml
@@ -1,0 +1,33 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2beta2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "http-app.fullname" . }}
+  labels:
+    {{- include "http-app.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "http-app.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      name: memory
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/charts/http-app/templates/ingress.yaml
+++ b/charts/http-app/templates/ingress.yaml
@@ -1,0 +1,46 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "http-app.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+{{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
+  {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
+  {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
+  {{- end }}
+{{- end }}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "http-app.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+    cert-manager.io/cluster-issuer: clicampo-staging-letsencrypt-production
+    kubernetes.io/ingress.class: traefik-external
+    kubernetes.io/tls-acme: "true"
+    traefik.ingress.kubernetes.io/router.entrypoints: websecure
+    traefik.ingress.kubernetes.io/router.tls: "true"
+  {{- end }}
+spec:
+  tls:
+    - hosts:
+        - {{ .Values.ingress.host | quote }}
+      secretName: {{ $fullName }}-tls
+  rules:
+    - host: {{ .Values.ingress.host | quote }}
+      http:
+        paths:
+          - path: /
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+{{- end }}

--- a/charts/http-app/templates/secret.yaml
+++ b/charts/http-app/templates/secret.yaml
@@ -1,0 +1,17 @@
+{{- $fullName := include "http-app.fullname" . -}}
+
+{{- if and .Values.vaultSecret.enabled .Values.vaultSecret.data }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $fullName }}-secret
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    vault.security.banzaicloud.io/vault-addr: {{ .Values.vaultSecret.vault.address }}
+    vault.security.banzaicloud.io/vault-role: {{ .Values.vaultSecret.vault.role }}
+    vault.security.banzaicloud.io/vault-path: {{ .Values.vaultSecret.vault.path }}
+stringData:
+  {{ range $key, $value := .Values.vaultSecret.data }}
+  {{ $key }}: {{ $value }}
+  {{ end }}
+{{- end }}

--- a/charts/http-app/templates/service.yaml
+++ b/charts/http-app/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "http-app.fullname" . }}
+  labels:
+    {{- include "http-app.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "http-app.selectorLabels" . | nindent 4 }}

--- a/charts/http-app/values.yaml
+++ b/charts/http-app/values.yaml
@@ -1,0 +1,43 @@
+replicaCount: 1
+
+image:
+  repository: tutum/hello-world
+  pullPolicy: IfNotPresent
+
+env:
+  # - name: SAMPLE_VAULT_SECRET
+  #   fromVault: true
+  # - name: SAMPLE_PLAINT_TEXT_ENV
+  #   value: "Hello World"
+
+vaultSecret:
+  enabled: false
+  # vault:
+  #   address: https://my.vault.host
+  #   role: my-vault-role
+  #   path: my/secret/path
+  # data:
+  #   SAMPLE_VAULT_SECRET: ${my/secret/path#key}
+
+service:
+  type: ClusterIP
+  port: 80
+
+ingress:
+  enabled: true
+  host: http-api.staging.clicampo.com
+  # annotations:
+
+resources:
+  requests:
+    cpu: 500m
+    memory: 256Mi
+  limits:
+    cpu: 1000m
+    memory: 1024Mi
+
+autoscaling:
+  enabled: true
+  minReplicas: 1
+  maxReplicas: 3
+  targetCPUUtilizationPercentage: 80


### PR DESCRIPTION
# what
- Added a new helm chart called `http-app`, it exposes any container that listens to HTTP connections on a certain port

# why
to make sexy applications easily sexier