### PR TITLE
feat(http-app)!: use envFrom to create secrets from Vault

### DIFF
--- a/charts/http-app/Chart.yaml
+++ b/charts/http-app/Chart.yaml
@@ -9,9 +9,9 @@ maintainers:
     email: henrique.cunha@clicampo.com.br
   - name: Gabriel Montañola
     email: gabriel@montanola.com
-    
+
 sources:
   - https://github.com/clicampo/helm-charts
 
 type: application
-version: "0.3.0"
+version: "1.0.0"

--- a/charts/http-app/templates/deployment.yaml
+++ b/charts/http-app/templates/deployment.yaml
@@ -56,13 +56,13 @@ spec:
             - name: {{ $element.name }}
               {{- if $element.value }}
               value: {{ $element.value }}
-              {{- else if $element.fromVault }}
-              valueFrom:
-                secretKeyRef:
-                  name: {{ $fullName }}-secret
-                  key: {{ $element.name }}
               {{- end }}
             {{- end }}
+          {{- end }}
+          {{- if .Values.vaultSecret.enabled }}
+          envFrom:
+            - secretRef:
+              name: {{ $fullName }}-secret
           {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/charts/http-app/templates/deployment.yaml
+++ b/charts/http-app/templates/deployment.yaml
@@ -62,7 +62,7 @@ spec:
           {{- if .Values.vaultSecret.enabled }}
           envFrom:
             - secretRef:
-              name: {{ $fullName }}-secret
+                name: {{ $fullName }}-secret
           {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/charts/http-app/values.yaml
+++ b/charts/http-app/values.yaml
@@ -10,8 +10,6 @@ healthcheck:
   # delay: 10
 
 env:
-  # - name: SAMPLE_VAULT_SECRET
-  #   fromVault: true
   # - name: SAMPLE_PLAINT_TEXT_ENV
   #   value: "Hello World"
 
@@ -44,7 +42,7 @@ resources:
     memory: 1024Mi
 
 autoscaling:
-  enabled: true
+  enabled: false
   minReplicas: 1
   maxReplicas: 3
   targetCPUUtilizationPercentage: 80


### PR DESCRIPTION
The screenshot is old. I fixed secretRef -> name indentation in [`a08ab0a` (#4)](https://github.com/clicampo/helm-charts/pull/4/commits/a08ab0a1ba4e09b2183d3c4b28d70ef076b15189). 

![image](https://user-images.githubusercontent.com/35972814/167946194-b9afeee5-54b1-44e7-9d2b-0c4b1444b877.png)
