### PR TITLE
fix(http-app): quote env to make int values safe

### DIFF
--- a/charts/http-app/Chart.yaml
+++ b/charts/http-app/Chart.yaml
@@ -17,4 +17,4 @@ sources:
   - https://github.com/clicampo/helm-charts
 
 type: application
-version: "2.0.0"
+version: "2.0.1"

--- a/charts/http-app/templates/deployment.yaml
+++ b/charts/http-app/templates/deployment.yaml
@@ -51,7 +51,7 @@ spec:
             {{- range $element := .Values.env }}
             - name: {{ $element.name }}
               {{- if $element.value }}
-              value: {{ $element.value }}
+              value: {{ $element.value | quote }}
               {{- end }}
             {{- end }}
           {{- end }}

--- a/charts/http-app/values.yaml
+++ b/charts/http-app/values.yaml
@@ -29,9 +29,12 @@ readinessProbe:
   # failureThreshold: 1
   # periodSeconds: 50
 
-env: []
-#  - name: SAMPLE_PLAINT_TEXT_ENV
-#    value: "Hello World"
+env:
+  []
+  # - name: SAMPLE_PLAIN_TEXT_ENV
+  #   value: "Hello World"
+  # - name: SAMPLE_INT_ENV
+  #   value: 420
 
 vaultSecret:
   enabled: false


### PR DESCRIPTION
k8s hate integer in envs

https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#envvar-v1-core

![image](https://user-images.githubusercontent.com/35972814/171396029-85148054-bd0e-454a-a809-d5dd3ea3b62f.png)
