### PR TITLE
feat: add deployment annotations template

### DIFF
--- a/charts/http-app/Chart.yaml
+++ b/charts/http-app/Chart.yaml
@@ -17,4 +17,4 @@ sources:
   - https://github.com/clicampo/helm-charts
 
 type: application
-version: "2.1.1"
+version: "2.2.0"

--- a/charts/http-app/templates/deployment.yaml
+++ b/charts/http-app/templates/deployment.yaml
@@ -4,6 +4,10 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ $fullName }}
+  {{- with .Values.deploymentAnnotations }}
+  annotations:
+        {{- toYaml . | nindent 4 }}
+  {{- end }}
   labels:
     {{- include "http-app.labels" . | nindent 4 }}
 spec:


### PR DESCRIPTION
this is useful to define 1password annotations as they're required at the deployment level e.g:

```yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  annotations:
    operator.1password.io/item-path: "vaults/staging/items/braincolis"
    operator.1password.io/item-name: "braincolis-secrets"
```